### PR TITLE
As this is an exception, we need to be able to set 'name=None'

### DIFF
--- a/fmc_rest_client/core/base_resources.py
+++ b/fmc_rest_client/core/base_resources.py
@@ -215,7 +215,7 @@ class ContainedPolicyResource(PolicyResource):
         return ['container']
 
 class Device(NamedResource):
-    def __init__(self, name, id=None):
+    def __init__(self, name=None, id=None):
         super().__init__(name, id)
         self.metadata = Metadata()
 


### PR DESCRIPTION
so that we can do a fmc.list(Device()) to get a list of devices.
This should fix the previous commit.